### PR TITLE
Add option of custom branch prefix

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,27 @@ Add the following to the `.pre-commit-config.yaml` file in you repo.
 
 Then, install `pre-commit` hooks (usually `pre-commit install`). 
 
+### Customizing the branch prefix
+
+By default the hook looks for branches named `fb-{JIRA_TAG}` (e.g.
+`fb-PROJ-123-some-feature`). The prefix that precedes the Jira key is
+configurable via the `--prefix` argument; the Jira key pattern itself
+(`[A-Z]+-[0-9]+`) is fixed.
+
+``` yaml
+        -   id: add-jira-tag
+            name: add-jira-tag
+            stages: [ prepare-commit-msg ]
+            args: [ "--prefix", "feat-" ]
+```
+
+The prefix is a regex fragment, so an alternation works too — this matches
+`task-`, `feat-`, or `fix-` branches:
+
+``` yaml
+            args: [ "--prefix", "(task|feat|fix)-" ]
+```
+
 > :warning: **`add-jira-tag` is a `prepare-commit-msg` hook**, so passing additional arguments `--install-hooks -t prepare-commit-msg` may be required during hooks installation.
 
 ---

--- a/add_jira_tag.sh
+++ b/add_jira_tag.sh
@@ -1,17 +1,46 @@
 #!/usr/bin/env bash
 
+# The branch prefix that precedes the Jira tag. May be a regex (e.g.
+# "(task|feat|fix)-"). Overridable via `--prefix <regex>` (e.g. in pre-commit's
+# `args:`). The Jira capture groups that follow it are fixed.
+prefix="fb-"
+
+# Parse hook options. pre-commit prepends `args:` before git's own arguments,
+# so consume known options first, then read git's positional arguments.
+while [[ $# -gt 0 ]]
+do
+    case "$1" in
+        --prefix)
+            prefix=$2
+            shift 2
+            ;;
+        --prefix=*)
+            prefix=${1#--prefix=}
+            shift
+            ;;
+        *)
+            break
+            ;;
+    esac
+done
+
 # Git will pass the commit msg as an argument to prepare-commit-msg hook.
 # See https://git-scm.com/docs/githooks#_prepare_commit_msg.
 commit_msg_filepath=$1
 
 branch_name=$(git branch --show-current)
 
-regex="fb-([A-Z]+-[0-9]+)(-.*)?"
+regex="${prefix}([A-Z]+-[0-9]+)(-.*)?"
 if [[ $branch_name =~ $regex ]]
 then
+    # The prefix may itself contain capture groups (bash uses POSIX ERE, which
+    # has no non-capturing groups, so e.g. "(task|feat|fix)-" needs one). That
+    # would shift BASH_REMATCH indices, so re-extract the Jira key from the
+    # matched text instead of trusting a fixed group index.
+    [[ ${BASH_REMATCH[0]} =~ ([A-Z]+-[0-9]+) ]]
     jira_issue=${BASH_REMATCH[1]}
 else
-    echo Branch is not in format 'fb-{JIRA_TAG}'. Skipping...
+    echo "Branch is not in format '${prefix}{JIRA_TAG}'. Skipping..."
     exit 0
 fi
 

--- a/tests/test_add_jira_tag.py
+++ b/tests/test_add_jira_tag.py
@@ -7,6 +7,8 @@ import subprocess
 import sys
 from pathlib import Path
 
+import pytest
+
 
 SCRIPT_PATH = Path(__file__).parent.parent / "add_jira_tag.sh"
 
@@ -39,14 +41,25 @@ def _get_git_bash() -> str:
     return "bash"  # Fall back to PATH.
 
 
-def _run_hook(tmp_path: Path, commit_msg: str, branch_name: str = "fb-PROJ-123-feature") -> tuple[str, str, str, int]:
+def _run_hook(
+    tmp_path: Path,
+    commit_msg: str,
+    branch_name: str = "fb-PROJ-123-feature",
+    args: list[str] | None = None,
+) -> tuple[str, str, str, int]:
     """
     Run the hook script with a mocked git branch command.
+
+    ``args`` are extra hook options (e.g. ``["--prefix", "feat-"]``) injected
+    before git's positional commit-message argument, mirroring pre-commit's
+    ``args:`` behaviour.
 
     Returns (stdout, stderr, result_msg, returncode).
     """
     msg_file = tmp_path / "COMMIT_EDITMSG"
     msg_file.write_text(commit_msg)
+
+    extra_args = " ".join(f'"{arg}"' for arg in (args or []))
 
     wrapper_script = f'''
 git() {{
@@ -58,7 +71,7 @@ git() {{
 }}
 export -f git
 
-source "{SCRIPT_PATH.as_posix()}"
+source "{SCRIPT_PATH.as_posix()}" {extra_args} "$@"
 '''
     wrapper_file = tmp_path / "wrapper.sh"
     wrapper_file.write_text(wrapper_script)
@@ -262,3 +275,77 @@ def test_old_format_different_tag_preserved(tmp_path: Path) -> None:
     assert result_msg.startswith("[OTHER-456] Add feature")
     assert "OTHER-456\n" not in result_msg.split("\n", 1)[1]  # Old tag removed from end.
     assert "Converting old format tag" in stdout
+
+
+def test_custom_prefix_adds_tag(tmp_path: Path) -> None:
+    """A custom --prefix matches a branch with that prefix and tags the title."""
+    stdout, stderr, result_msg, code = _run_hook(
+        tmp_path,
+        "Add feature\n",
+        branch_name="feat-PROJ-123-some-feature",
+        args=["--prefix", "feat-"],
+    )
+    assert code == 0, f"Exit code {code}, stderr: {stderr}"
+    assert result_msg == "[PROJ-123] Add feature\n"
+    assert "Adding tag" in stdout
+
+
+def test_custom_prefix_equals_form(tmp_path: Path) -> None:
+    """The --prefix=<value> form is also supported."""
+    stdout, stderr, result_msg, code = _run_hook(
+        tmp_path,
+        "Add feature\n",
+        branch_name="feat-PROJ-123-some-feature",
+        args=["--prefix=feat-"],
+    )
+    assert code == 0, f"Exit code {code}, stderr: {stderr}"
+    assert result_msg == "[PROJ-123] Add feature\n"
+
+
+def test_default_prefix_still_works_with_no_args(tmp_path: Path) -> None:
+    """With no args the default 'fb-' prefix keeps working (regression)."""
+    stdout, stderr, result_msg, code = _run_hook(tmp_path, "Add feature\n")
+    assert code == 0, f"Exit code {code}, stderr: {stderr}"
+    assert result_msg == "[PROJ-123] Add feature\n"
+
+
+def test_custom_prefix_skips_default_fb_branch(tmp_path: Path) -> None:
+    """When a custom prefix is set, a default 'fb-' branch no longer matches."""
+    input_msg = "Add feature\n"
+    stdout, stderr, result_msg, code = _run_hook(
+        tmp_path,
+        input_msg,
+        branch_name="fb-PROJ-123-feature",
+        args=["--prefix", "feat-"],
+    )
+    assert code == 0, f"Exit code {code}, stderr: {stderr}"
+    assert result_msg == input_msg  # Unchanged.
+    assert "Skipping" in stdout
+
+
+@pytest.mark.parametrize("branch_prefix", ["task", "feat", "fix"])
+def test_alternation_prefix_triggers_for_each(tmp_path: Path, branch_prefix: str) -> None:
+    """An alternation prefix '(task|feat|fix)-' matches any of the three."""
+    stdout, stderr, result_msg, code = _run_hook(
+        tmp_path,
+        "Add feature\n",
+        branch_name=f"{branch_prefix}-PROJ-1-some-feature",
+        args=["--prefix", "(task|feat|fix)-"],
+    )
+    assert code == 0, f"Exit code {code}, stderr: {stderr}"
+    assert result_msg == "[PROJ-1] Add feature\n"
+    assert "Adding tag" in stdout
+
+
+def test_alternation_prefix_skips_non_member(tmp_path: Path) -> None:
+    """A branch prefix outside the alternation set is skipped."""
+    input_msg = "Add feature\n"
+    stdout, stderr, result_msg, code = _run_hook(
+        tmp_path,
+        input_msg,
+        branch_name="chore-PROJ-1-some-feature",
+        args=["--prefix", "(task|feat|fix)-"],
+    )
+    assert code == 0, f"Exit code {code}, stderr: {stderr}"
+    assert result_msg == input_msg  # Unchanged.
+    assert "Skipping" in stdout


### PR DESCRIPTION
The `add-jira-tag` hook currently only works for branches with their names in the format `fb-<Jira tag>-<other stuff>`.

This PR generalises the hook to accept different prefixes (as a regex), which allows using the hook in an environment which uses another naming standard.

This is being used currently in an environment which relies on branches named `feat/<Jira tag>-<other stuff>` and `task/<Jira tag>-<other stuff>`, and we thought it would be a reasonable contribution for the overall hook.